### PR TITLE
[FIX] Error handling for none tag

### DIFF
--- a/client/src/components/problemDetail.tsx
+++ b/client/src/components/problemDetail.tsx
@@ -198,14 +198,16 @@ const ProblemDetail = ({item}:any) =>{
             </WhiteLevelBox>
             <TagBoxWrapper>
             <TagBox>
-                {item.tags.split(',').map(
+                {item.tags == null ? item.tags.split(',').map(
                     (tag : string, i : number) => 
                     <TagItemWrapper key={i}>
                         <ProblemLink href = {`https://solved.ac/problems/tags/${tag}`} target='_blank'>
                             #{tag}
                         </ProblemLink>
                     </TagItemWrapper>
-                )}
+                ): <TagItemWrapper>
+                    태그 정보가 없습니다.
+                    </TagItemWrapper>}
             </TagBox>
             </TagBoxWrapper>
             <SolvedInfoBoxWrapper>


### PR DESCRIPTION
문제에 대한 태그 정보가 없을 때 split 메소드를 찾지 못해 페이지에서 에러가 나는 현상을 해결했습니다.